### PR TITLE
Add optional Serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,17 @@ repository = "https://github.com/enarx/flagset"
 homepage = "https://github.com/enarx/flagset"
 documentation = "https://docs.rs/flagset"
 description = "Data types and a macro for generating enumeration-based bit flags"
+
+[dependencies.serde]
+version = "1.0"
+optional = true
+features = [ "serde_derive" ]
+
+[dev-dependencies.serde_json]
+version = "1.0"
+
+[dev-dependencies.serde_repr]
+version = "0.1"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -179,3 +179,49 @@ Operations can be performed on a `FlagSet<F>` or on individual flags:
 | %        | %=                  | Symmetric difference   |
 | !        |                     | Toggle all flags       |
 
+## Optional Serde support
+
+[Serde] support can be enabled with the 'serde' feature flag. You can then serialize and
+deserialize `FlagSet<T>` to and from any of the [supported formats]:
+
+ ```rust
+ use flagset::{FlagSet, flags};
+
+ flags! {
+     enum Flags: u8 {
+         Foo,
+         Bar,
+     }
+ }
+
+ let flagset = Flags::Foo | Flags::Bar;
+ let json = serde_json::to_string(&flagset).unwrap();
+ let flagset: FlagSet<Flags> = serde_json::from_str(&json).unwrap();
+ assert_eq!(flagset.bits(), 0b011);
+ ```
+
+For serialization and deserialization of flags enum itself, you can use the [`serde_repr`] crate
+(or implement `serde::ser::Serialize` and `serde:de::Deserialize` manually), combined with the
+appropriate `repr` attribute:
+
+ ```rust
+ use flagset::{FlagSet, flags};
+ use serde_repr::{Serialize_repr, Deserialize_repr};
+
+ flags! {
+    #[repr(u8)]
+    #[derive(Deserialize_repr, Serialize_repr)]
+    enum Flags: u8 {
+         Foo,
+         Bar,
+    }
+ }
+
+ let json = serde_json::to_string(&Flags::Foo).unwrap();
+ let flag: Flags = serde_json::from_str(&json).unwrap();
+ assert_eq!(flag, Flags::Foo);
+ ```
+
+[Serde]: https://serde.rs/
+[supported formats]: https://serde.rs/#data-formats
+[`serde_repr`]: https://crates.io/crates/serde_repr


### PR DESCRIPTION
When `serde` feature is explicitly enabled, we implement `serde::Serialize` and `serde::Deserialize` for the flags and `FlagsSet<T>`.