### PR TITLE
Add `const` to `new_unchecked()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -840,7 +840,7 @@ impl<F: Flags> FlagSet<F> {
     /// }
     ///
     /// // Unknown and invalid bits are retained. Behavior is undefined.
-    /// let set = unsafe { FlagSet::<Flag>::new_unchecked(0b11101) };
+    /// const set: FlagSet<Flag> = unsafe { FlagSet::<Flag>::new_unchecked(0b11101) };
     /// assert_eq!(set.bits(), 0b11101);
     /// ```
     ///
@@ -849,7 +849,7 @@ impl<F: Flags> FlagSet<F> {
     /// This constructor doesn't check that the bits are valid. If you pass
     /// undefined flags, undefined behavior may result.
     #[inline]
-    pub unsafe fn new_unchecked(bits: F::Type) -> Self {
+    pub const unsafe fn new_unchecked(bits: F::Type) -> Self {
         FlagSet(bits)
     }
 


### PR DESCRIPTION
I have a need to have a `FlagSet` in a compile-time constant, which wasn't possible before, so I simply added `const` to `new_unchecked`.

I didn't add `const` to the other `new_*` functions due to the `Flag::Type` calling `default()` which is [not yet possible](https://github.com/rust-lang/rust/issues/67792) in a `const` context.

While it is unfortunate that you have to have an unsafe block to have a `FlagSet` in a constant, it is however better than it not being possible at all. :P