### PR TITLE
chore: bump minimum Rust to 1.65

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.56.0
+          - 1.65.0
         profile:
           - name: debug
           - name: release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "flagset"
 version = "0.4.3"
 authors = ["Nathaniel McCallum <nathaniel@profian.com>"]
-edition = "2018"
-rust-version = "1.56"
+edition = "2021"
+rust-version = "1.65"
 
 license = "Apache-2.0"
 keywords = ["flags", "bitflags", "enum", "enumflags"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56"
+channel = "1.65"
 profile = "minimal"


### PR DESCRIPTION
Bump minimum version of Rust to 1.65 (November 2022) so that https://github.com/enarx/flagset/pull/28 may be accepted.

CC: @CuriouslyCurious