### PR TITLE
Std error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ version = "0.1"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ homepage = "https://github.com/enarx/flagset"
 documentation = "https://docs.rs/flagset"
 description = "Data types and a macro for generating enumeration-based bit flags"
 
+[features]
+std = []
+
 [dependencies.serde]
 version = "1.0"
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,7 @@ appropriate `repr` attribute:
 #![allow(unknown_lints)]
 #![warn(clippy::all)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ appropriate `repr` attribute:
 )]
 #![allow(unknown_lints)]
 #![warn(clippy::all)]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use core::fmt::{Debug, Formatter, Result};
 use core::ops::*;
@@ -275,6 +275,9 @@ impl core::fmt::Display for InvalidBits {
         write!(f, "invalid bits")
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidBits {}
 
 #[doc(hidden)]
 pub trait Flags:


### PR DESCRIPTION
This PR adds `std::error::Error`  implementation for `InvalidBits`. The impl is hidden behind a new `std` feature to ensure no_std compatibility out of the box.

Also I enabled the `doc_auto_cfg` feature for `docs.rs` builds so the docs get these nice little hints for stuff that is behind a feature flag:
![](https://i.imgur.com/2ZNz6Ra.png)

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
